### PR TITLE
 Validar que un usuario no pueda comprar más de 4 entradas por evento

### DIFF
--- a/app/forms/ticket_form.py
+++ b/app/forms/ticket_form.py
@@ -98,6 +98,7 @@ class TicketForm(forms.Form):
     )
     
     cantidadTk = forms.IntegerField(
+        min_value=1,
         label="Ingrese la cantidad",
         widget=forms.NumberInput(attrs={'class': 'form-control'})
     )

--- a/app/models.py
+++ b/app/models.py
@@ -1,6 +1,7 @@
 from django.contrib.auth.models import AbstractUser
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
+from django.core.exceptions import ValidationError
 
 
 # === MODELOS PARA USERs ===
@@ -148,7 +149,12 @@ class Ticket(models.Model):
 
     def __str__(self):
         texto = "{0} ({1})"
-        return texto.format(self.ticket_code, self.buy_date)  
+        return texto.format(self.ticket_code, self.buy_date)
+    
+    def save(self, *args, **kwargs):
+        if self.quantity > 4:
+            raise ValidationError("No se puede comprar más de 4 tickets.")
+        super().save(*args, **kwargs)
 
 
 # === MODELOS PARA RATINGs ===

--- a/app/test/test_e2e/test_ticket.py
+++ b/app/test/test_e2e/test_ticket.py
@@ -1,0 +1,114 @@
+import datetime
+import re
+
+from django.utils import timezone
+from playwright.sync_api import expect
+
+from app.models import Event, User
+
+from app.test.test_e2e.base import BaseE2ETest
+
+
+class LimitTicketTest(BaseE2ETest):
+
+    def setUp(self):
+        super().setUp()
+
+        # Crear usuario organizador
+        self.organizer = User.objects.create_user(
+            username="organizador",
+            email="organizador@example.com",
+            password="password123",
+            is_organizer=True,
+        )
+
+        # Crear usuario regular
+        self.regular_user = User.objects.create_user(
+            username="usuario",
+            email="usuario@example.com",
+            password="password123",
+            is_organizer=False,
+        )
+
+        # Crear eventos de prueba
+        # Evento 1
+        event_date1 = timezone.make_aware(datetime.datetime(2025, 2, 10, 10, 10))
+        self.event1 = Event.objects.create(
+            title="Evento de prueba 1",
+            description="Descripción del evento 1",
+            scheduled_at=event_date1,
+            organizer=self.organizer,
+        )
+
+    def test_validate_limit_purchase(self):
+
+        # Iniciar sesión como organizador
+       self.login_user("usuario", "password123")
+
+        # Ir a la página de eventos
+       self.page.goto(f"{self.live_server_url}/events/")
+
+        # Hacer clic en el primer link de ver detalle de evento
+       with self.page.expect_navigation():
+           self.page.locator("a[aria-label='Ver detalle']").first.click()
+
+       create_button = self.page.get_by_role("link", name="Comprar entrada")
+       expect(create_button).to_be_visible()
+       create_button.click()
+
+       # confirmar que se dirige al template donde se encuentra el formulario del ticket
+       expect(self.page).to_have_url(f"{self.live_server_url}/tickets/entrada/{self.event1.pk}")
+       
+       # confirmo la existencia del formulario
+       form = self.page.locator('form[action="/tickets/confirmarEntrada"]')
+       expect(form).to_be_visible()
+
+       # cargo el formulario
+       self.page.fill('input[name="cantidad"]', '4')
+       self.page.select_option('select[name="tipo"]', 'general')
+       self.page.fill('input[name="numero_tarjeta"]', '1234567812345678')
+       self.page.fill('input[name="expiracion"]', '12/30')
+       self.page.fill('input[name="cvv"]', '123')
+       self.page.fill('input[name="nombre_tarjeta"]', 'Juan Pérez')
+       self.page.check('input[name="acepta_terminos"]')
+
+       # Enviar el formulario 
+       self.page.get_by_role("button", name="Confirmar Compra").click()
+
+       # Verificar que redirige , demostrando la compra exitosa 
+       expect(self.page).to_have_url(re.compile(".*/tickets/gestion.*"))
+
+       # vuelvo a la pagima de eventos
+       self.page.goto(f"{self.live_server_url}/events/")
+
+       # Hacer clic en el primer link de ver detalle de evento
+       with self.page.expect_navigation():
+           self.page.locator("a[aria-label='Ver detalle']").first.click()
+
+       # Intento realizar otro ticket superando el limite de entradas.
+       create_button = self.page.get_by_role("link", name="Comprar entrada")
+       expect(create_button).to_be_visible()
+       create_button.click()
+
+       expect(self.page).to_have_url(f"{self.live_server_url}/tickets/entrada/{self.event1.pk}")
+
+       form = self.page.locator('form[action="/tickets/confirmarEntrada"]')
+       expect(form).to_be_visible()
+
+       self.page.fill('input[name="cantidad"]', '1')
+       self.page.select_option('select[name="tipo"]', 'general')
+       self.page.fill('input[name="numero_tarjeta"]', '1234567812345678')
+       self.page.fill('input[name="expiracion"]', '12/30')
+       self.page.fill('input[name="cvv"]', '123')
+       self.page.fill('input[name="nombre_tarjeta"]', 'Juan Pérez')
+       self.page.check('input[name="acepta_terminos"]')
+
+       # 4. Enviar el formulario 
+       self.page.get_by_role("button", name="Confirmar Compra").click()
+
+       # verifico que en la respuesta se encuentre el mensaje de error.
+       error_list = self.page.locator("ul.errorlist li")
+       expect(error_list).to_contain_text("superarías el límite de 4 entradas")
+
+
+    

--- a/app/test/test_integration/test_ticket.py
+++ b/app/test/test_integration/test_ticket.py
@@ -1,7 +1,6 @@
 from django.test import TestCase, Client
 from django.urls import reverse
 from django.utils import timezone
-from datetime import datetime
 from ...models import Event, Ticket, User
 
 class ConfirmTicketViewTest(TestCase):
@@ -25,7 +24,7 @@ class ConfirmTicketViewTest(TestCase):
         self.event = Event.objects.create(
             title="Evento de prueba",
             description="Descripción del evento de prueba",
-            scheduled_at=datetime.now(),
+            scheduled_at=timezone.now(),
             organizer=self.organizer,
         )
         self.url = reverse('confirm_ticket')  # Asegúrate que este nombre esté en tu urls.py
@@ -38,7 +37,7 @@ class ConfirmTicketViewTest(TestCase):
             'cantidad': 2,
             'tipo': 'general',
             'numero_tarjeta': '1234567812345678',
-            'expiracion': datetime.now().strftime('%m/%y'),
+            'expiracion': timezone.now().strftime('%m/%y'),
             'cvv': '123',
             'nombre_tarjeta': 'Juan Pérez',
             'acepta_terminos': True,
@@ -62,7 +61,7 @@ class ConfirmTicketViewTest(TestCase):
             'cantidad': 2,
             'tipo': 'general',
             'numero_tarjeta': '1234567812345678',
-            'expiracion': datetime.now().strftime('%m/%y'),
+            'expiracion': timezone.now().strftime('%m/%y'),
             'cvv': '123',
             'nombre_tarjeta': 'Juan Pérez',
             'acepta_terminos': True,

--- a/app/test/test_integration/test_ticket.py
+++ b/app/test/test_integration/test_ticket.py
@@ -1,0 +1,78 @@
+from django.test import TestCase, Client
+from django.urls import reverse
+from django.utils import timezone
+from datetime import datetime
+from ...models import Event, Ticket, User
+
+class ConfirmTicketViewTest(TestCase):
+
+    def setUp(self):
+        self.client = Client()
+        # crea un usuario organizador
+        self.organizer = User.objects.create_user(
+            username="organizador",
+            email="organizador@test.com",
+            password="password123",
+            is_organizer=True,
+        )
+         # Crear un usuario regular
+        self.regular_user = User.objects.create_user(
+            username="regular",
+            email="regular@test.com",
+            password="password123",
+            is_organizer=False,
+        )
+        self.event = Event.objects.create(
+            title="Evento de prueba",
+            description="Descripción del evento de prueba",
+            scheduled_at=datetime.now(),
+            organizer=self.organizer,
+        )
+        self.url = reverse('confirm_ticket')  # Asegúrate que este nombre esté en tu urls.py
+
+    def test_ticket_compra_valida(self):
+        self.client.login(username="regular", password="password123")
+
+        form_data = {
+            'id_evento': self.event.pk,
+            'cantidad': 2,
+            'tipo': 'general',
+            'numero_tarjeta': '1234567812345678',
+            'expiracion': datetime.now().strftime('%m/%y'),
+            'cvv': '123',
+            'nombre_tarjeta': 'Juan Pérez',
+            'acepta_terminos': True,
+        }
+
+        response = self.client.post(self.url, data=form_data)
+
+        # Se espera una redirección si la compra fue válida
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(Ticket.objects.filter(usuario=self.regular_user, evento=self.event).exists())
+
+
+    def test_ticket_excede_limite(self):
+        self.client.login(username="regular", password="password123")
+
+        # Usuario ya compró 3 entradas
+        Ticket.objects.create(usuario=self.regular_user, evento=self.event, quantity=3, type='general', buy_date=timezone.now())
+
+        form_data = {
+            'id_evento': self.event.pk,
+            'cantidad': 2,
+            'tipo': 'general',
+            'numero_tarjeta': '1234567812345678',
+            'expiracion': datetime.now().strftime('%m/%y'),
+            'cvv': '123',
+            'nombre_tarjeta': 'Juan Pérez',
+            'acepta_terminos': True,
+        }
+
+        response = self.client.post(self.url, data=form_data)
+
+        # Debe retornar el formulario con error (código 200, no redirección)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "superarías el límite de 4 entradas")
+        self.assertEqual(Ticket.objects.filter(usuario=self.regular_user, evento=self.event).count(), 1)  # No se creó uno nuevo
+
+    

--- a/app/test/test_unit/test_ticket.py
+++ b/app/test/test_unit/test_ticket.py
@@ -2,7 +2,6 @@ from django.test import TestCase
 from django.core.exceptions import ValidationError
 from ...models import Ticket, Event, User
 from django.utils import timezone
-from datetime import datetime
 
 class TicketModelTest(TestCase):
     def setUp(self):
@@ -15,7 +14,7 @@ class TicketModelTest(TestCase):
         self.event = Event.objects.create(
             title="Evento de prueba",
             description="Descripción del evento de prueba",
-            scheduled_at=datetime.now(),
+            scheduled_at=timezone.now(),
             organizer=self.user,
         )
 
@@ -24,7 +23,7 @@ class TicketModelTest(TestCase):
             usuario=self.user,
             evento=self.event,
             quantity=5,
-            buy_date=datetime.now(),
+            buy_date=timezone.now(),
             type="general"
         )
         with self.assertRaises(ValidationError) as context:
@@ -37,7 +36,7 @@ class TicketModelTest(TestCase):
             usuario=self.user,
             evento=self.event,
             quantity=3,
-            buy_date=datetime.now(),
+            buy_date=timezone.now(),
             type="general",
         )
         try:

--- a/app/test/test_unit/test_ticket.py
+++ b/app/test/test_unit/test_ticket.py
@@ -1,0 +1,46 @@
+from django.test import TestCase
+from django.core.exceptions import ValidationError
+from ...models import Ticket, Event, User
+from django.utils import timezone
+from datetime import datetime
+
+class TicketModelTest(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="organizador_test",
+            email="organizador@example.com",
+            password="password123",
+            is_organizer=True,
+        )
+        self.event = Event.objects.create(
+            title="Evento de prueba",
+            description="Descripción del evento de prueba",
+            scheduled_at=datetime.now(),
+            organizer=self.user,
+        )
+
+    def test_ticket_quantity_no_mayor_a_4(self):
+        ticket = Ticket(
+            usuario=self.user,
+            evento=self.event,
+            quantity=5,
+            buy_date=datetime.now(),
+            type="general"
+        )
+        with self.assertRaises(ValidationError) as context:
+            ticket.save()
+
+        self.assertIn("No se puede comprar más de 4 tickets", str(context.exception))
+
+    def test_ticket_quantity_valida(self):
+        ticket = Ticket(
+            usuario=self.user,
+            evento=self.event,
+            quantity=3,
+            buy_date=datetime.now(),
+            type="general",
+        )
+        try:
+            ticket.save()
+        except ValidationError:
+            self.fail("El ticket con quantity <= 4 no debería lanzar ValidationError")

--- a/app/views.py
+++ b/app/views.py
@@ -4,12 +4,11 @@ from django.contrib import messages
 from django.contrib.auth import authenticate, login
 from django.contrib.auth.decorators import login_required
 from django.core.paginator import Paginator
-from django.db.models import Q
+from django.db.models import Q, Sum
 from django.http import HttpResponseBadRequest, HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
 from django.utils.timezone import localtime
-
 from .forms import CompraTicketForm, NotificationForm, RatingForm, RefundRequestForm, TicketForm
 from .models import Comment, Event, Notification, Rating, RefundRequest, Ticket, User
 
@@ -444,12 +443,25 @@ def edit_ticket(request, id):
 
 @login_required
 def update_ticket(request):
+    usuario = request.user
     form = TicketForm(request.POST)
     if form.is_valid():
             tipo = form.cleaned_data['tipoEntrada']
             cantidad = form.cleaned_data['cantidadTk']
             id = form.cleaned_data['ticketCode']
             tk = get_object_or_404(Ticket, ticket_code=id)
+            event = tk.evento
+            
+            entradas_existentes = Ticket.objects.filter(
+            usuario=usuario,
+            evento=event).aggregate(total=Sum("quantity"))["total"] or 0
+
+            entradas_existentes = entradas_existentes - tk.quantity
+
+            if entradas_existentes + cantidad > 4:
+                form.add_error('cantidadTk',f"Ya has comprado {entradas_existentes + tk.quantity} entradas para este evento. "
+            f"Con esta compra ({cantidad - tk.quantity }) superarías el límite de 4 entradas.")
+                return render(request, "ticket/edicionTicket.html",{ "form": form})
             tk.quantity = cantidad
             tk.type = tipo
             tk.save()
@@ -476,6 +488,22 @@ def confirm_ticket(request):
         event = get_object_or_404(Event, pk=id_evento)
         cantidad = form.cleaned_data['cantidad']
         tipo = form.cleaned_data['tipo']
+
+         # Validación: no permitir más de 4 entradas por usuario por evento
+        entradas_existentes = Ticket.objects.filter(
+            usuario=usuario,
+            evento=event
+        ).aggregate(total=Sum("quantity"))["total"] or 0
+
+        if entradas_existentes + cantidad > 4:
+            form.add_error('cantidad',f"Ya has comprado {entradas_existentes} entradas para este evento. "
+            f"Con esta compra ({cantidad}) superarías el límite de 4 entradas.")
+            return render(request, "ticket/entrada.html", {
+                "user_is_organizer": usuario.is_organizer,
+                "evento": event,
+                "form": form
+            })
+        
         Ticket.objects.create( quantity=cantidad , buy_date=timezone.now(), type=tipo, usuario=usuario, evento = event)
         return redirect('gestion_ticket', idEvento= id_evento)
     else:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-DJANGO_SETTINGS_MODULE = eventhub.settings
-python_files = tests.py test_*.py *_tests.py

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = eventhub.settings
+python_files = tests.py test_*.py *_tests.py


### PR DESCRIPTION
## Descripción
Esta PR Evita que un usuario no pueda comprar más de 4 entradas por evento dando un error en formulario de compra.

## Cambios realizados
- Se realizaron cambios en el modelo Ticket para evitar la creacion del mismo con cantidad de entradas mayores a 4.
- Se valida en las views confirm_ticket y update_ticket que no se puedan crear o actualizar tickets con mas de 4 entradas.

## Issue relacionada
- Closes #3
